### PR TITLE
remove a leftover debug echom ?

### DIFF
--- a/config/theme.vim
+++ b/config/theme.vim
@@ -276,7 +276,6 @@ if !exists('g:Vimmic_DisableDefaultColors')
       else
          execute 'highlight StatusLineLeft ctermbg='.g:StatusLeftBG.' ctermfg='.g:StatusLeftFG
          execute 'highlight StatusLineTerm ctermbg='.g:StatusNCBG.' ctermfg='.g:StatusTerminalFG
-         execute 'echom '.g:StatusLeftBG
       endif
    endfunction
 


### PR DESCRIPTION
I'm not entirely sure what this line was supposed to do, but to me it seems like a leftover debug print and it caused vim to pause at startup and ask me to press a key:

```
$ vim
4
4
Appuyez sur ENTRÉE ou tapez une commande pour continuer
```

Is it ok to remove it?